### PR TITLE
CRAN's p_set_cranrepo is buggy

### DIFF
--- a/R/p_set_cranrepo.R
+++ b/R/p_set_cranrepo.R
@@ -20,12 +20,4 @@ p_set_cranrepo <- function(default_repo = "http://cran.rstudio.com/"){
     if(length(repos) == 0){
         options(repos = default_repo)
     }
-    
-    # Add ripley's repos on windows
-    if(p_detectOS() == "Windows"){
-        if(is.na(options()$repo["CRANextra"])){
-            options(repos = c(options()$repos, 
-                             CRANextra = "http://www.stats.ox.ac.uk/pub/RWin"))
-        }
-    }
 }


### PR DESCRIPTION
Since this package is not being updated on CRAN with trinker's new code, I'll request this pull (I don't speak SVN so this is the best I can do) to at least fix the buggy ```p_set_cranrepo``` that currently leads to:

```
Warning message:
In options()$repo : partial match of 'repo' to 'repos' 
```

For those with such warning messages enabled.

Credits go to ```mmcgowan13```'s 3-year-old fix on pull request ```ebe9b9d```.
